### PR TITLE
Fix ParseAmount default string

### DIFF
--- a/BillParser.Client/Code/Models.cs
+++ b/BillParser.Client/Code/Models.cs
@@ -30,7 +30,7 @@ namespace BillParser.Client.Code
         {
             if (amt.ToUpper() is "INCLUDED" or "-")
             {
-                amt = new string("0.00");
+                amt = "0.00";
             }
             return decimal.Parse(amt.Split("$").Last().ToString());
         }


### PR DESCRIPTION
## Summary
- simplify `ParseAmount` replacement string assignment

## Testing
- `dotnet test` *(fails: Could not find PDF test files)*

------
https://chatgpt.com/codex/tasks/task_e_68649c3905a88324aa17ec82dd99c183