### PR TITLE
Rename test method

### DIFF
--- a/BillParser.Test/BillParserTest.cs
+++ b/BillParser.Test/BillParserTest.cs
@@ -14,7 +14,7 @@ namespace BillParser.Test
         }
 
         [Fact]
-        public async Task ChechIfTotalsMatchAsync()
+        public async Task CheckIfTotalsMatchAsync()
         {
             var path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Desktop), "SummaryBillOct2024.pdf");
             var summarySection = await PdfPig.GetSummarySectionAsync(await File.ReadAllBytesAsync(path));


### PR DESCRIPTION
## Summary
- fix a typo in `BillParserTest` method `CheckIfTotalsMatchAsync`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68649c2a464c832488a6acb06917f45e